### PR TITLE
chore(lint): ignore vendored/example paths

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,3 @@
+{
+  "ignores": ["examples/**"]
+}


### PR DESCRIPTION
## Summary
Add `.markdownlint-cli2.jsonc` to ignore vendored/example paths from canonical lint enforcement.

The canonical lint rules from `qte77/.github/.markdownlint.jsonc` continue to apply via the runtime fallback; this file only narrows which files are linted.

Generated with Claude <noreply@anthropic.com>