### PR TITLE
ci(lint): bump SHA pin and add scheduled monitor

### DIFF
--- a/.github/workflows/lint-md-links.yml
+++ b/.github/workflows/lint-md-links.yml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   lint:
-    uses: qte77/.github/.github/workflows/lint-md-links.yml@3b1579152e930a53b13d987a9c2344f79e3007d5  # 2026-04-27
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
 ...

--- a/.github/workflows/lint-monitor.yml
+++ b/.github/workflows/lint-monitor.yml
@@ -1,0 +1,21 @@
+---
+name: Lint Monitor
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # weekly Sunday midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  monitor:
+    uses: qte77/.github/.github/workflows/lint-md-links.yml@5dfff1f73ac7241ef37b6103e04d2a8373ff68a4  # 2026-04-27
+    with:
+      notify_on_failure: true
+    permissions:
+      contents: read
+      issues: write
+...


### PR DESCRIPTION
## Summary
- Bump `lint-md-links.yml` `uses:` SHA to current `qte77/.github` main (2026-04-27)
- Add `lint-monitor.yml`: weekly cron + `workflow_dispatch`, calls the centralized lint workflow with `notify_on_failure: true` (creates an issue if a scheduled run fails)

## Why
Replaces the per-repo `links-fail-fast.yaml` pattern (cron + issue-on-fail) using the centralized opt-in input added in `qte77/.github` PR #16. Single source of truth for lint logic; each repo opts into monitoring.

Generated with Claude <noreply@anthropic.com>