### PR TITLE
feat(agents): CLAUDE.md symlink to AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+results/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,1 @@
-# Agent Configuration
-
-<!-- ORCHESTRATOR CONFIGURATION
-- Separate orchestrator and subagent configurations
-- Main agent reads AGENTS.md for full pipeline orchestration
-- Subagents read SUBAGENTS.md for specific implementation
--->
-
-- **Main orchestrator agent** (general-purpose): @AGENTS.md
-- **All specialized subagents** (source-project-analyst, industry-landscape-researcher, etc.): @SUBAGENTS.md
+AGENTS.md


### PR DESCRIPTION
## Summary

- `CLAUDE.md`: replaced stub file with symlink to `AGENTS.md` (Claude Code bridge; Codex/Gemini read AGENTS.md natively)

Part of estate-wide AGENTS.md-only agent config standardization.

## Test plan

- [ ] Confirm `CLAUDE.md` is a symlink: `file CLAUDE.md`

Generated with Claude <noreply@anthropic.com>